### PR TITLE
Improve line connections

### DIFF
--- a/react/src/context/CanvasContext.js
+++ b/react/src/context/CanvasContext.js
@@ -59,7 +59,9 @@ function canvasReducer(state, action) {
       const newLine = {
         id: crypto.randomUUID(),
         startBoxId: action.startBoxId,
-        endBoxId: action.endBoxId
+        endBoxId: action.endBoxId,
+        startPosition: action.startPosition,
+        endPosition: action.endPosition
       };
       
       const updatedLevelWithLine = {


### PR DESCRIPTION
This PR improves the line connection functionality:

- Lines now connect between nodes instead of box centers
- Connection nodes appear on hover instead of click
- Added visual feedback for hovered nodes
- Lines maintain their connection points when boxes are moved
- Cancel line creation when clicking outside of a node