### PR TITLE
Add shadcn styling and improved visuals

### DIFF
--- a/react/src/App.js
+++ b/react/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Canvas from './components/Canvas';
 import Toolbar from './components/Toolbar';
 import { CanvasProvider } from './context/CanvasContext';
+import './styles/globals.css';
 
 function App() {
   return (

--- a/react/src/components/Canvas.js
+++ b/react/src/components/Canvas.js
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react';
 import { useCanvas } from '../context/CanvasContext';
+import { ColorPicker } from './ui/color-picker';
 
 function Canvas() {
   const canvasRef = useRef(null);
@@ -65,21 +66,56 @@ function Canvas() {
         const startNode = getBoxNodes(startBox).find(n => n.position === line.startPosition);
         const endNode = getBoxNodes(endBox).find(n => n.position === line.endPosition);
         
+        // Draw line
         ctx.beginPath();
+        ctx.strokeStyle = '#6C757D';
+        ctx.lineWidth = 2;
         ctx.moveTo(startNode.x, startNode.y);
         ctx.lineTo(endNode.x, endNode.y);
         ctx.stroke();
+        
+        // Draw arrow
+        const angle = Math.atan2(endNode.y - startNode.y, endNode.x - startNode.x);
+        const arrowLength = 15;
+        const arrowWidth = 8;
+        
+        ctx.beginPath();
+        ctx.fillStyle = '#6C757D';
+        ctx.moveTo(endNode.x, endNode.y);
+        ctx.lineTo(
+          endNode.x - arrowLength * Math.cos(angle) + arrowWidth * Math.sin(angle),
+          endNode.y - arrowLength * Math.sin(angle) - arrowWidth * Math.cos(angle)
+        );
+        ctx.lineTo(
+          endNode.x - arrowLength * Math.cos(angle) - arrowWidth * Math.sin(angle),
+          endNode.y - arrowLength * Math.sin(angle) + arrowWidth * Math.cos(angle)
+        );
+        ctx.closePath();
+        ctx.fill();
       }
     });
 
     // Draw boxes
     currentLevel.boxes.forEach(box => {
-      ctx.fillStyle = '#ffffff';
-      ctx.strokeStyle = '#000000';
+      ctx.fillStyle = box.backgroundColor || '#E9ECEF';
+      ctx.strokeStyle = box.borderColor || '#ADB5BD';
       ctx.lineWidth = 2;
       
-      ctx.fillRect(box.x, box.y, box.width, box.height);
-      ctx.strokeRect(box.x, box.y, box.width, box.height);
+      // Draw box with rounded corners
+      const radius = 8;
+      ctx.beginPath();
+      ctx.moveTo(box.x + radius, box.y);
+      ctx.lineTo(box.x + box.width - radius, box.y);
+      ctx.quadraticCurveTo(box.x + box.width, box.y, box.x + box.width, box.y + radius);
+      ctx.lineTo(box.x + box.width, box.y + box.height - radius);
+      ctx.quadraticCurveTo(box.x + box.width, box.y + box.height, box.x + box.width - radius, box.y + box.height);
+      ctx.lineTo(box.x + radius, box.y + box.height);
+      ctx.quadraticCurveTo(box.x, box.y + box.height, box.x, box.y + box.height - radius);
+      ctx.lineTo(box.x, box.y + radius);
+      ctx.quadraticCurveTo(box.x, box.y, box.x + radius, box.y);
+      ctx.closePath();
+      ctx.fill();
+      ctx.stroke();
       
       // Draw connection nodes if box is hovered
       if (hoveredBox && hoveredBox.id === box.id) {
@@ -283,6 +319,45 @@ function Canvas() {
           }}
           autoFocus
         />
+      )}
+      {hoveredBox && (
+        <div
+          style={{
+            position: 'absolute',
+            left: hoveredBox.x + hoveredBox.width + 10,
+            top: hoveredBox.y,
+            display: 'flex',
+            gap: '8px',
+            padding: '8px',
+            background: 'white',
+            borderRadius: '4px',
+            boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+            zIndex: 1000
+          }}
+        >
+          <div className="flex flex-col gap-2">
+            <div className="text-sm font-medium">Background</div>
+            <ColorPicker
+              color={hoveredBox.backgroundColor || '#E9ECEF'}
+              onChange={(color) => dispatch({
+                type: 'UPDATE_BOX_STYLE',
+                boxId: hoveredBox.id,
+                style: { backgroundColor: color }
+              })}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <div className="text-sm font-medium">Border</div>
+            <ColorPicker
+              color={hoveredBox.borderColor || '#ADB5BD'}
+              onChange={(color) => dispatch({
+                type: 'UPDATE_BOX_STYLE',
+                boxId: hoveredBox.id,
+                style: { borderColor: color }
+              })}
+            />
+          </div>
+        </div>
       )}
     </div>
   );

--- a/react/src/components/ui/button.jsx
+++ b/react/src/components/ui/button.jsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+const Button = React.forwardRef(({ className, variant, size, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : "button"
+  return (
+    <Comp
+      className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/react/src/components/ui/color-picker.jsx
+++ b/react/src/components/ui/color-picker.jsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+import { cn } from "@/lib/utils"
+
+const ColorPicker = React.forwardRef(({ className, color, onChange, ...props }, ref) => {
+  return (
+    <PopoverPrimitive.Root>
+      <PopoverPrimitive.Trigger asChild>
+        <button
+          className={cn(
+            "h-6 w-6 rounded-md border border-input",
+            className
+          )}
+          style={{ backgroundColor: color }}
+          ref={ref}
+          {...props}
+        />
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          className="z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none"
+          align="start"
+        >
+          <div className="grid grid-cols-6 gap-2">
+            {[
+              "#FFFFFF", "#F8F9FA", "#E9ECEF", "#DEE2E6", "#CED4DA", "#ADB5BD",
+              "#6C757D", "#495057", "#343A40", "#212529", "#000000",
+              "#FF6B6B", "#F06595", "#CC5DE8", "#845EF7", "#5C7CFA", "#339AF0",
+              "#22B8CF", "#20C997", "#51CF66", "#94D82D", "#FCC419", "#FF922B"
+            ].map((c) => (
+              <button
+                key={c}
+                className={cn(
+                  "h-6 w-6 rounded-md border border-input",
+                  color === c && "ring-2 ring-ring"
+                )}
+                style={{ backgroundColor: c }}
+                onClick={() => onChange(c)}
+              />
+            ))}
+          </div>
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  )
+})
+ColorPicker.displayName = "ColorPicker"
+
+export { ColorPicker }

--- a/react/src/context/CanvasContext.js
+++ b/react/src/context/CanvasContext.js
@@ -36,9 +36,11 @@ function canvasReducer(state, action) {
         id: crypto.randomUUID(),
         x: action.x + offsetX,
         y: action.y + offsetY,
-        width: 150,
-        height: 100,
-        text: 'New Box'
+        width: 200,
+        height: 120,
+        text: 'New Box',
+        backgroundColor: '#E9ECEF',
+        borderColor: '#ADB5BD'
       };
       
       const updatedLevel = {
@@ -146,6 +148,25 @@ function canvasReducer(state, action) {
       return {
         ...state,
         levels: levelsWithUpdatedText
+      };
+
+    case 'UPDATE_BOX_STYLE':
+      const levelWithStyle = state.levels.get(state.currentLevelId);
+      const updatedBoxesWithStyle = levelWithStyle.boxes.map(box =>
+        box.id === action.boxId ? { ...box, ...action.style } : box
+      );
+      
+      const updatedLevelWithStyle = {
+        ...levelWithStyle,
+        boxes: updatedBoxesWithStyle
+      };
+      
+      const levelsWithUpdatedStyle = new Map(state.levels);
+      levelsWithUpdatedStyle.set(state.currentLevelId, updatedLevelWithStyle);
+      
+      return {
+        ...state,
+        levels: levelsWithUpdatedStyle
       };
 
     default:

--- a/react/src/lib/utils.js
+++ b/react/src/lib/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+ 
+export function cn(...inputs) {
+  return twMerge(clsx(inputs))
+}

--- a/react/src/styles/globals.css
+++ b/react/src/styles/globals.css
@@ -1,0 +1,76 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+ 
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+ 
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+ 
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+ 
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+ 
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+ 
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+ 
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+ 
+    --radius: 0.5rem;
+  }
+ 
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+ 
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+ 
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+ 
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+ 
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+ 
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+ 
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+ 
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+ 
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+  }
+}
+ 
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}


### PR DESCRIPTION
This PR adds visual improvements to match the example image:

- Add shadcn UI components and styling
- Add configurable box colors with color picker
- Add directional arrows to lines
- Add rounded corners to boxes
- Update box dimensions and default colors
- Add hover controls for box styling